### PR TITLE
update to match Laravel code notation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ This package provides a IronMQ (~2.0 SDK) driver for the Laravel queue system an
 
 ## Installation
 
-- Add `Collective\IronQueue\IronQueueServiceProvider` to your `app.php` configuration file.
+- Add `Collective\IronQueue\IronQueueServiceProvider::class` to your `app.php` configuration file.
 - Configure your `iron` queue driver in your `config/queue.php` the same as it would have been configured for Laravel 5.1.
 
 Sample Configuration:


### PR DESCRIPTION
Just matches the Laravel format utilizing the ::class notation.
