### PR TITLE
Control reservation timeouts when popping a new item off the queue

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,5 +17,6 @@ Sample Configuration:
     'project' => 'your-project-id',
     'queue'   => 'your-queue-name',
     'encrypt' => true,
+    'timeout' => 60
 ],
 ```

--- a/src/Connectors/IronConnector.php
+++ b/src/Connectors/IronConnector.php
@@ -60,6 +60,6 @@ class IronConnector implements ConnectorInterface
             $iron->ssl_verifypeer = $config['ssl_verifypeer'];
         }
 
-        return new IronQueue($iron, $this->request, $config['queue'], $config['encrypt']);
+        return new IronQueue($iron, $this->request, $config['queue'], $config['encrypt'], $config['timeout']);
     }
 }

--- a/src/IronQueue.php
+++ b/src/IronQueue.php
@@ -49,11 +49,11 @@ class IronQueue extends Queue implements QueueContract
     /**
      * Create a new IronMQ queue instance.
      *
-     * @param \IronMQ\IronMQ $iron
+     * @param \IronMQ\IronMQ           $iron
      * @param \Illuminate\Http\Request $request
-     * @param string $default
-     * @param bool $shouldEncrypt
-     * @param int $timeout
+     * @param string                   $default
+     * @param bool                     $shouldEncrypt
+     * @param int                      $timeout
      */
     public function __construct(IronMQ $iron, Request $request, $default, $shouldEncrypt = false, $timeout = 60)
     {

--- a/src/IronQueue.php
+++ b/src/IronQueue.php
@@ -40,21 +40,28 @@ class IronQueue extends Queue implements QueueContract
     protected $shouldEncrypt;
 
     /**
+     * Number of seconds before the reservation_id times out on a newly popped message.
+     *
+     * @var int
+     */
+    protected $timeout;
+
+    /**
      * Create a new IronMQ queue instance.
      *
-     * @param \IronMQ\IronMQ           $iron
+     * @param \IronMQ\IronMQ $iron
      * @param \Illuminate\Http\Request $request
-     * @param string                   $default
-     * @param bool                     $shouldEncrypt
-     *
-     * @return void
+     * @param string $default
+     * @param bool $shouldEncrypt
+     * @param int $timeout
      */
-    public function __construct(IronMQ $iron, Request $request, $default, $shouldEncrypt = false)
+    public function __construct(IronMQ $iron, Request $request, $default, $shouldEncrypt = false, $timeout = 60)
     {
         $this->iron = $iron;
         $this->request = $request;
         $this->default = $default;
         $this->shouldEncrypt = $shouldEncrypt;
+        $this->timeout = $timeout;
     }
 
     /**
@@ -135,7 +142,7 @@ class IronQueue extends Queue implements QueueContract
     {
         $queue = $this->getQueue($queue);
 
-        $job = $this->iron->reserveMessage($queue);
+        $job = $this->iron->reserveMessage($queue, $this->timeout);
 
         // If we were able to pop a message off of the queue, we will need to decrypt
         // the message body, as all Iron.io messages are encrypted, since the push

--- a/tests/IronQueueTest.php
+++ b/tests/IronQueueTest.php
@@ -118,7 +118,6 @@ class IronQueueTest extends PHPUnit_Framework_TestCase
     {
         $queue = new Collective\IronQueue\IronQueue($iron = m::mock('IronMQ\IronMQ'), m::mock('Illuminate\Http\Request'), 'default', false, 30);
         $iron->shouldReceive('deleteMessage')->with('default', 1, 'def456')->andThrow('IronCore\HttpException', '{"msg":"Reservation has timed out"}');
-        
         // 'def456' refers to a reservation id that expired
         $queue->deleteMessage('default', 1, 'def456');
     }

--- a/tests/IronQueueTest.php
+++ b/tests/IronQueueTest.php
@@ -111,21 +111,19 @@ class IronQueueTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Collective\IronQueue\Jobs\IronJob', $result);
     }
 
+    /**
+     * @expectedException IronCore\HttpException
+     */
     public function testDeleteJobWithExpiredReservationIdThrowsAnException()
     {
         $queue = new Collective\IronQueue\IronQueue($iron = m::mock('IronMQ\IronMQ'), m::mock('Illuminate\Http\Request'), 'default', false, 30);
-        //$crypt = m::mock('Illuminate\Contracts\Encryption\Encrypter');
-        //$queue->setEncrypter($crypt);
-        //$queue->setContainer(m::mock('Illuminate\Container\Container'));
+
         $iron->shouldReceive('deleteMessage')->with('default', 1, 'def456')->andThrow('IronCore\HttpException', '{"msg":"Reservation has timed out"}');
 
-        //$job->body = 'foo';
-        //$crypt->shouldReceive('decrypt')->never();
         
         // 'def456' refers to a reservation id that expired
         $queue->deleteMessage('default', 1, 'def456');
 
-        //$this->assertInstanceOf('Collective\IronQueue\Jobs\IronJob', $result);
     }
 
     public function testPushedJobsCanBeMarshaled()

--- a/tests/IronQueueTest.php
+++ b/tests/IronQueueTest.php
@@ -75,7 +75,21 @@ class IronQueueTest extends PHPUnit_Framework_TestCase
         $crypt = m::mock('Illuminate\Contracts\Encryption\Encrypter');
         $queue->setEncrypter($crypt);
         $queue->setContainer(m::mock('Illuminate\Container\Container'));
-        $iron->shouldReceive('reserveMessage')->once()->with('default')->andReturn($job = m::mock('IronMQ_Message'));
+        $iron->shouldReceive('reserveMessage')->once()->with('default', 60)->andReturn($job = m::mock('IronMQ_Message'));
+        $job->body = 'foo';
+        $crypt->shouldReceive('decrypt')->once()->with('foo')->andReturn('foo');
+        $result = $queue->pop();
+
+        $this->assertInstanceOf('Collective\IronQueue\Jobs\IronJob', $result);
+    }
+
+    public function testPopProperlyPopsJobOffOfIronWithCustomTimeout()
+    {
+        $queue = new Collective\IronQueue\IronQueue($iron = m::mock('IronMQ\IronMQ'), m::mock('Illuminate\Http\Request'), 'default', true, 120);
+        $crypt = m::mock('Illuminate\Contracts\Encryption\Encrypter');
+        $queue->setEncrypter($crypt);
+        $queue->setContainer(m::mock('Illuminate\Container\Container'));
+        $iron->shouldReceive('reserveMessage')->once()->with('default', 120)->andReturn($job = m::mock('IronMQ_Message'));
         $job->body = 'foo';
         $crypt->shouldReceive('decrypt')->once()->with('foo')->andReturn('foo');
         $result = $queue->pop();
@@ -89,12 +103,29 @@ class IronQueueTest extends PHPUnit_Framework_TestCase
         $crypt = m::mock('Illuminate\Contracts\Encryption\Encrypter');
         $queue->setEncrypter($crypt);
         $queue->setContainer(m::mock('Illuminate\Container\Container'));
-        $iron->shouldReceive('reserveMessage')->once()->with('default')->andReturn($job = m::mock('IronMQ_Message'));
+        $iron->shouldReceive('reserveMessage')->once()->with('default', 60)->andReturn($job = m::mock('IronMQ_Message'));
         $job->body = 'foo';
         $crypt->shouldReceive('decrypt')->never();
         $result = $queue->pop();
 
         $this->assertInstanceOf('Collective\IronQueue\Jobs\IronJob', $result);
+    }
+
+    public function testDeleteJobWithExpiredReservationIdThrowsAnException()
+    {
+        $queue = new Collective\IronQueue\IronQueue($iron = m::mock('IronMQ\IronMQ'), m::mock('Illuminate\Http\Request'), 'default', false, 30);
+        //$crypt = m::mock('Illuminate\Contracts\Encryption\Encrypter');
+        //$queue->setEncrypter($crypt);
+        //$queue->setContainer(m::mock('Illuminate\Container\Container'));
+        $iron->shouldReceive('deleteMessage')->with('default', 1, 'def456')->andThrow('IronCore\HttpException', '{"msg":"Reservation has timed out"}');
+
+        //$job->body = 'foo';
+        //$crypt->shouldReceive('decrypt')->never();
+        
+        // 'def456' refers to a reservation id that expired
+        $queue->deleteMessage('default', 1, 'def456');
+
+        //$this->assertInstanceOf('Collective\IronQueue\Jobs\IronJob', $result);
     }
 
     public function testPushedJobsCanBeMarshaled()

--- a/tests/IronQueueTest.php
+++ b/tests/IronQueueTest.php
@@ -117,13 +117,10 @@ class IronQueueTest extends PHPUnit_Framework_TestCase
     public function testDeleteJobWithExpiredReservationIdThrowsAnException()
     {
         $queue = new Collective\IronQueue\IronQueue($iron = m::mock('IronMQ\IronMQ'), m::mock('Illuminate\Http\Request'), 'default', false, 30);
-
         $iron->shouldReceive('deleteMessage')->with('default', 1, 'def456')->andThrow('IronCore\HttpException', '{"msg":"Reservation has timed out"}');
-
         
         // 'def456' refers to a reservation id that expired
         $queue->deleteMessage('default', 1, 'def456');
-
     }
 
     public function testPushedJobsCanBeMarshaled()


### PR DESCRIPTION
The upgrade to iron core 4.0 introduced reservation_id usage when deleting messages after a job.

The reservation_id is obtained when `Queue::pop()`-ing a new message off the queue, but takes an option `$timeout` parameter, which defaults to 60s.

If a job completes successfully, but takes longer than those default 60s, `$job->delete()` will fail with a `IronCore\HttpException`.

TLDR; If an IronJob takes longer than 60 seconds and finishes successfully, it cannot be deleted from the queue due to the reservation id expiring.

This PR introduces a `timeout` config variable which allows control over how fast reservation id's expire.
