### PR TITLE
Update composer to use laravel components from 5.7 to 5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": ">=5.6.4",
         "illuminate/container": "5.8.*",
         "illuminate/contracts": "5.8.*",
         "illuminate/encryption": "5.8.*",

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
-        "illuminate/container": "5.7.*",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/encryption": "5.7.*",
-        "illuminate/http": "5.7.*",
-        "illuminate/queue": "5.7.*",
-        "illuminate/support": "5.7.*",
+        "php": "^7.1.3",
+        "illuminate/container": "5.8.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/encryption": "5.8.*",
+        "illuminate/http": "5.8.*",
+        "illuminate/queue": "5.8.*",
+        "illuminate/support": "5.8.*",
         "iron-io/iron_mq": "~4.0",
         "jeremeamia/superclosure": "~2.0"
     },


### PR DESCRIPTION
Updated laravel illuminate components from 5.7 to 5.8

I sendt this pull request to 5.7 branch since I have no access to create a new branch in the repository and the master branch is not in sync with latest version.